### PR TITLE
Log error reports.

### DIFF
--- a/src/error_logger_log4erl_h.erl
+++ b/src/error_logger_log4erl_h.erl
@@ -66,8 +66,10 @@ handle_event({info_msg, _GLeader, {_PID, Msg, Data}}, #elogger_l4e_mappings{info
 handle_event({warning_msg, _GLeader, {_PID, Msg, Data}}, #elogger_l4e_mappings{warning_msg=L} = State) ->
     R = log4erl:log(L, Msg, Data),
     {R, State};
-handle_event({error_report, _GLeader, _}, State) ->
-    {ok, State};
+handle_event({error_report, _GLeader, {_PID, Type, Report}},
+             #elogger_l4e_mappings{error_report=L} = State) ->
+    R = log4erl:log(L, "~p:~n~p", [Type, Report]),
+    {R, State};
 handle_event({info_report, _GLeader, _}, State) ->
     {ok, State};
 handle_event({warning_report, _GLeader, _}, State) ->


### PR DESCRIPTION
I would expect error reports (crash reports etc) to wind up in the log when log4erl is registered as a error_logger handler. This little path adds that functionality.
