### PR TITLE
Use latest Mochiweb

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,6 @@
 %% -*- mode: erlang -*-
 
-{deps, [{mochiweb, "1.5.1",
-         {git, "git://github.com/mochi/mochiweb.git",
-          {tag, "1.5.1"}}}]}.
+{deps, [
+			{mochiweb, ".*", {git, "git://github.com/mochi/mochiweb.git", {branch, "master"}}}
+		]
+}.


### PR DESCRIPTION
Now parameterized modules are no longer supported in R16, older versions of mochiweb will not compile, hence have updated the rebar.config to use latest mochiweb.
