### PR TITLE
Update smtp_fsm.erl

### DIFF
--- a/src/smtp_fsm.erl
+++ b/src/smtp_fsm.erl
@@ -108,7 +108,7 @@ hexit(Int) ->
 %% generates MD5 mac and returns as hex string
 md5_hmac(Challenge,Pwd) ->
     crypto:start(),
-    Md5_bin = crypto:md5_mac(Pwd,Challenge),
+    Md5_bin = crypto:hmac(md5, Pwd, Challenge),
     crypto:stop(),
     hexdigest(Md5_bin).
 


### PR DESCRIPTION
crypto:md5_mac/2 is deprecated and will be removed in in a future release, so

``` Erlang
crypto:md5_mac/2
```

should be replased with

``` Erlang
crypto:hmac/3
```
