### PR TITLE
Signal errors when lexing

### DIFF
--- a/src/log4erl_conf.erl
+++ b/src/log4erl_conf.erl
@@ -9,8 +9,9 @@ leex(File) ->
     case R of
 	{ok, Tokens, _} ->
 	    Tokens;
-	_ ->
-	    io:format("Error ~p~n",[R])
+	Error ->
+	    io:format("Error ~p~n",[R]),
+	    erlang:error(Error, [File])
     end.
 
 parse(Tokens) ->


### PR DESCRIPTION
If leex detects an error in the configuration file, the function
log4erl_conf:leex currently prints the error and returns ok.  The
function log4erl_conf:parse then takes the return value and hands it
to log4erl_parser:parse, which fails with a cryptic error message that
suggests that something went wrong inside the parser:

    > log4erl:conf("/tmp/bad").
    Error {error,{1,log4erl_lex,{illegal,"'"}},1}
    ** exception error: no function clause matching
                        log4erl_parser:yeccpars1(ok,{no_func,no_line},0,[],[]) (/usr/lib/erlang/lib/parsetools-2.0.12/include/yeccpre.hrl, line 82)
         in function  log4erl_parser:yeccpars0/5 (/usr/lib/erlang/lib/parsetools-2.0.12/include/yeccpre.hrl, line 56)
         in call from log4erl_conf:parse/1 (src/log4erl_conf.erl, line 17)
         in call from log4erl_conf:conf/1 (src/log4erl_conf.erl, line 28)

With this change, the error is raised earlier, and the error message
points out exactly where the error is:

    > log4erl:conf("/tmp/bad").
    Error {error,{1,log4erl_lex,{illegal,"'"}},1}
    ** exception error: {error,{1,log4erl_lex,{illegal,"'"}},1}
         in function  log4erl_conf:leex/1
            called as log4erl_conf:leex("/tmp/bad")
         in call from log4erl_conf:conf/1 (src/log4erl_conf.erl, line 29)