### PR TITLE
Fix broken dependency after branch rename

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %% -*- mode: erlang -*-
 
 {deps, [
-			{mochiweb, ".*", {git, "https://github.com/mochi/mochiweb.git", {branch, "master"}}}
+			{mochiweb, ".*", {git, "https://github.com/mochi/mochiweb.git", {branch, "main"}}}
 		]
 }.


### PR DESCRIPTION
Mochiweb renamed their main branch to "main" instead of "master" which breaks rebar when fetching dependencies.